### PR TITLE
dev: add tor from repo to standalone

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -60,15 +60,13 @@ LABEL server_version=$JM_SERVER_REPO_REF
 RUN apt-get update \
     && apt-get install -qq --no-install-recommends --no-install-suggests -y gnupg curl apt-transport-https ca-certificates \
     # add nginx debian repo
-    && sh -c "echo 'deb https://nginx.org/packages/mainline/debian/ bullseye nginx' > /etc/apt/sources.list.d/nginx.list" \
     && curl --silent https://nginx.org/keys/nginx_signing.key | \
-    gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/nginx.gpg --import \
-    && chmod 644 /etc/apt/trusted.gpg.d/nginx.gpg \
+    gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg > /dev/null \
+    && sh -c "echo 'deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/mainline/debian/ bullseye nginx' > /etc/apt/sources.list.d/nginx.list" \
     # add tor debian repo
-    && curl --silent https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import \
-    && gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add - \
-    && sh -c "echo 'deb https://deb.torproject.org/torproject.org bullseye main' > /etc/apt/sources.list.d/tor.list" \
-    && sh -c "echo 'deb-src https://deb.torproject.org/torproject.org bullseye main' >> /etc/apt/sources.list.d/tor.list"
+    && curl --silent https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | \
+    gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg > /dev/null \
+    && sh -c "echo 'deb [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org bullseye main' > /etc/apt/sources.list.d/tor.list"
 
 RUN apt-get update \
     && apt-get install -qq --no-install-recommends --no-install-suggests -y \
@@ -99,8 +97,7 @@ RUN rm --recursive --force install.sh deps/cache/ test/ .git/ .gitignore .github
 
 RUN apt-get clean \
     && apt-get remove --purge --auto-remove -y gnupg python3-pip apt-transport-https \
-    && rm --recursive --force /var/lib/apt/lists/* /etc/apt/trusted.gpg.d/* \
-    && rm --force /etc/apt/sources.list.d/nginx.list /etc/apt/sources.list.d/tor.list \
+    && rm --recursive --force /var/lib/apt/lists/* \
     && rm --force /var/log/dpkg.log
 
 WORKDIR /src/scripts

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -101,6 +101,8 @@ RUN mkdir --parents /etc/tor
 RUN ./install.sh --docker-install --with-local-tor --without-qt
 RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
 
+RUN ln /etc/tor/torrc /usr/local/etc/tor/torrc
+
 WORKDIR /src/scripts
 
 COPY .bashrc /root/.bashrc

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -72,6 +72,8 @@ RUN apt-get update \
     tini supervisor iproute2 procps vim \
     # servers dependencies (see `install.sh`)
     build-essential automake pkg-config libtool libltdl-dev python3-dev python3-setuptools python3-pip \
+    # tor dependencies
+    libevent-dev libssl-dev zlib1g-dev \
     # ui dependencies
     nginx \
     # ---
@@ -93,7 +95,10 @@ ENV DEFAULT_AUTO_START /root/autostart
 ENV AUTO_START ${DATADIR}/autostart
 ENV PATH /src/scripts:$PATH
 
-RUN ./install.sh --docker-install --without-qt
+# ensure /etc/tor exists - install script will create /etc/tor/torrc
+RUN mkdir --parents /etc/tor
+
+RUN ./install.sh --docker-install --with-local-tor --without-qt
 RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
 
 WORKDIR /src/scripts

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -95,13 +95,8 @@ ENV DEFAULT_AUTO_START /root/autostart
 ENV AUTO_START ${DATADIR}/autostart
 ENV PATH /src/scripts:$PATH
 
-# ensure /etc/tor exists - install script will create /etc/tor/torrc
-RUN mkdir --parents /etc/tor
-
 RUN ./install.sh --docker-install --with-local-tor --without-qt
 RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
-
-RUN ln /etc/tor/torrc /usr/local/etc/tor/torrc
 
 WORKDIR /src/scripts
 

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get update \
     tini supervisor iproute2 procps vim \
     # servers dependencies (see `install.sh`)
     build-essential automake pkg-config libtool libltdl-dev python3-dev python3-setuptools python3-pip \
-    # tor dependencies
-    libevent-dev libssl-dev zlib1g-dev \
+    # tor
+    tor \
     # ui dependencies
     nginx \
     # ---
@@ -95,12 +95,13 @@ ENV DEFAULT_AUTO_START /root/autostart
 ENV AUTO_START ${DATADIR}/autostart
 ENV PATH /src/scripts:$PATH
 
-RUN ./install.sh --docker-install --with-local-tor --without-qt
+RUN ./install.sh --docker-install --without-qt
 RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
 
 WORKDIR /src/scripts
 
 COPY .bashrc /root/.bashrc
+COPY torrc /etc/tor/torrc
 COPY autostart ${DEFAULT_AUTO_START}
 COPY default.cfg ${DEFAULT_CONFIG}
 COPY supervisor-conf/*.conf /etc/supervisor/conf.d/

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -58,30 +58,29 @@ LABEL ui_version=$JM_UI_REPO_REF
 LABEL server_version=$JM_SERVER_REPO_REF
 
 RUN apt-get update \
-    && apt-get install -qq --no-install-recommends --no-install-suggests -y gnupg curl \
-    && sh -c "echo 'deb http://nginx.org/packages/mainline/debian/ bullseye nginx' > /etc/apt/sources.list.d/nginx.list" \
-    && curl -s https://nginx.org/keys/nginx_signing.key | \
+    && apt-get install -qq --no-install-recommends --no-install-suggests -y gnupg curl apt-transport-https ca-certificates \
+    # add nginx debian repo
+    && sh -c "echo 'deb https://nginx.org/packages/mainline/debian/ bullseye nginx' > /etc/apt/sources.list.d/nginx.list" \
+    && curl --silent https://nginx.org/keys/nginx_signing.key | \
     gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/nginx.gpg --import \
     && chmod 644 /etc/apt/trusted.gpg.d/nginx.gpg \
-    && apt-get remove --purge --auto-remove -y gnupg
+    # add tor debian repo
+    && curl --silent https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import \
+    && gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add - \
+    && sh -c "echo 'deb https://deb.torproject.org/torproject.org bullseye main' > /etc/apt/sources.list.d/tor.list" \
+    && sh -c "echo 'deb-src https://deb.torproject.org/torproject.org bullseye main' >> /etc/apt/sources.list.d/tor.list"
 
 RUN apt-get update \
     && apt-get install -qq --no-install-recommends --no-install-suggests -y \
-    # ---
     # image dependencies
     tini supervisor iproute2 procps vim \
     # servers dependencies (see `install.sh`)
     build-essential automake pkg-config libtool libltdl-dev python3-dev python3-setuptools python3-pip \
     # tor
     tor \
+    deb.torproject.org-keyring \
     # ui dependencies
-    nginx \
-    # ---
-    && apt-get clean \
-    && apt-get remove --purge --auto-remove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -f /etc/apt/sources.list.d/nginx.list \
-    && rm -f /var/log/dpkg.log
+    nginx
 
 WORKDIR /src
 
@@ -96,7 +95,13 @@ ENV AUTO_START ${DATADIR}/autostart
 ENV PATH /src/scripts:$PATH
 
 RUN ./install.sh --docker-install --without-qt
-RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
+RUN rm --recursive --force install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
+
+RUN apt-get clean \
+    && apt-get remove --purge --auto-remove -y gnupg python3-pip apt-transport-https \
+    && rm --recursive --force /var/lib/apt/lists/* /etc/apt/trusted.gpg.d/* \
+    && rm --force /etc/apt/sources.list.d/nginx.list /etc/apt/sources.list.d/tor.list \
+    && rm --force /var/log/dpkg.log
 
 WORKDIR /src/scripts
 

--- a/standalone/autostart
+++ b/standalone/autostart
@@ -1,6 +1,7 @@
 # Remove comments in front of the services you want to automatically restart
 # when the container restarts.
 
+tor
 nginx
 ob-watcher
 jmwalletd

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-export JM_ONION_SERVING_HOST
-JM_ONION_SERVING_HOST="$(/sbin/ip route|awk '/src/ { print $9 }')"
-
 # ensure 'logs' directory exists
 mkdir --parents "${DATADIR}/logs"
 

--- a/standalone/supervisor-conf/tor.conf
+++ b/standalone/supervisor-conf/tor.conf
@@ -1,0 +1,9 @@
+[program:tor]
+command=/usr/local/bin/tor -f /usr/local/etc/tor/torrc
+autostart=false
+stdout_logfile=/root/.joinmarket/logs/tor_stdout.log
+stdout_logfile_maxbytes=5MB
+stdout_logfile_backups=0
+stderr_logfile=/root/.joinmarket/logs/tor_stderr.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=0

--- a/standalone/supervisor-conf/tor.conf
+++ b/standalone/supervisor-conf/tor.conf
@@ -1,5 +1,5 @@
 [program:tor]
-command=/usr/local/bin/tor -f /usr/local/etc/tor/torrc
+command=/usr/sbin/tor -f /etc/tor/torrc
 autostart=false
 stdout_logfile=/root/.joinmarket/logs/tor_stdout.log
 stdout_logfile_maxbytes=5MB

--- a/standalone/torrc
+++ b/standalone/torrc
@@ -1,0 +1,7 @@
+# Default JoinMarket Tor configuration
+# taken from v0.9.6 on 2022-07-18:
+# https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.6/install.sh#L388-L393
+Log warn stderr
+SOCKSPort 9050 IsolateDestAddr IsolateDestPort
+ControlPort 9051
+CookieAuthentication 1


### PR DESCRIPTION
Closes #43.

This PR adds Tor to the `standalone` image. 

Before this PR, an external container has been necessary to connect to IRC or to the directory nodes.
After this PR is applied, the image lives up to its name and is truly "standalone", meaning: No external dependencies. A Tor daemon will be started at the startup of the container.

The changes in this PR are up to debate and every input or suggestion is highly appreciated.

##### How to test?
This PR can be tested by following the instructions in [joinmarket-webui/#396 ](https://github.com/joinmarket-webui/joinmarket-webui/pull/396). A [build of this branch](https://github.com/joinmarket-webui/joinmarket-webui-docker/pkgs/container/joinmarket-webui-dev-standalone/28950781?tag=dev-with-local-tor-from-repo) has been made available as docker image, which is extended by the [secondary container in the regtest setup](https://github.com/joinmarket-webui/joinmarket-webui/blob/dev-regtest-with-local-tor/docker/regtest/dockerfile-deps/joinmarket/webui-standalone/Dockerfile#L1).

##### Addendum
Previous attempts included installing Tor from source via [flag `--with-local-tor` of joinmarket's `install.sh` script](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.6/install.sh#L375-L398).
This has been working great locally, but led to longer build times on GitHub's environment (from ~40min to up to ~2h(!)) and subsequently failing at the unit tests for Tor ([[1]](https://github.com/joinmarket-webui/joinmarket-webui-docker/actions/runs/2692769830), [[2]](https://github.com/joinmarket-webui/joinmarket-webui-docker/actions/runs/2696178784), [[3]](https://github.com/joinmarket-webui/joinmarket-webui-docker/actions/runs/2696771104)). [Installing it from an official repository (via `apt-get`)](https://github.com/joinmarket-webui/joinmarket-webui-docker/blob/dev-with-local-tor-from-repo/standalone/Dockerfile#L75-L76) is a compromise between ease of use and robustness. Before, it was relied upon an external container, where the sources where also "unknown", or, as e.g. in Umbrels case, totally outside of the users control. It is always possible for a user to switch to another instance by adapting and passing configuration variables.