### PR TITLE
feat: serve orderbook

### DIFF
--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -11,6 +11,12 @@ upstream jmwalletd_ws_backend {
     keepalive 2;
 }
 
+upstream obwatch_backend {
+    zone upstreams;
+    server 127.0.0.1:62601;
+    keepalive 2;
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -69,5 +75,20 @@ server {
         proxy_send_timeout 600s;
 
         proxy_pass https://jmwalletd_ws_backend/;
+    }
+
+    location /obwatch/ {
+        include /etc/nginx/snippets/proxy-params.conf;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        # allow 5 min (default is 60 sec). increase on demand.
+        proxy_read_timeout 300s;
+        # allow 5 min to connect (default is 60 sec)
+        proxy_connect_timeout 300s;
+
+        # must proxy via "http" as ob-watcher does not make use of self-signed cert yet
+        proxy_pass http://obwatch_backend/;
     }
 }

--- a/standalone/supervisor-conf/ob-watcher.conf
+++ b/standalone/supervisor-conf/ob-watcher.conf
@@ -1,6 +1,6 @@
 [program:ob-watcher]
 directory=/src/scripts/obwatch
-command=python ob-watcher.py --host 0.0.0.0
+command=python ob-watcher.py --host=127.0.0.1
 autostart=false
 stdout_logfile=/root/.joinmarket/logs/obwatch_stdout.log
 stdout_logfile_maxbytes=5MB


### PR DESCRIPTION
Serving the orderbook via nginx by passing requests to ob-watcher.py daemon.

Related to https://github.com/joinmarket-webui/joinmarket-webui/pull/422.

### How to test these changes?
- Checkout this branch and build the standalone docker image locally with 
```sh
docker build --label "local" \
        --build-arg JM_UI_REPO_REF=master \
        --build-arg JM_SERVER_REPO_REF=master \
        --tag "jam-serve-orderbook-standalone" ./standalone
```

- Checkout the branch `orderbook` for [PR#422](https://github.com/joinmarket-webui/joinmarket-webui/pull/422) in project `joinmarket-webui` and apply the following patch:
```patch
From b1a94581941cee920e90d314c141b150ad269244 Mon Sep 17 00:00:00 2001
From: theborakompanioni <theborakompanioni+github@gmail.com>
Date: Mon, 25 Jul 2022 14:56:12 -0600
Subject: [PATCH] dev: test serve-orderbook-docker-patch

---
 docker/regtest/docker-compose.yml                             | 4 ++--
 .../dockerfile-deps/joinmarket/webui-standalone/Dockerfile    | 2 +-
 src/setupProxy.js                                             | 4 ++--
 3 files changed, 5 insertions(+), 5 deletions(-)

diff --git a/docker/regtest/docker-compose.yml b/docker/regtest/docker-compose.yml
index b956eea..e51423d 100644
--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -59,8 +59,8 @@ services:
       READY_FILE: /root/.nbxplorer/btc_fully_synched
       ENSURE_WALLET: "true"
       REMOVE_LOCK_FILES: "true"
-      APP_USER: joinmarket
-      APP_PASSWORD: joinmarket
+      #APP_USER: joinmarket
+      #APP_PASSWORD: joinmarket
       jm_rpc_wallet_file: jm_secondary
       jm_minimum_makers: 1
       jm_tx_broadcast: self
diff --git a/docker/regtest/dockerfile-deps/joinmarket/webui-standalone/Dockerfile b/docker/regtest/dockerfile-deps/joinmarket/webui-standalone/Dockerfile
index 126e19e..acf1fa0 100644
--- a/docker/regtest/dockerfile-deps/joinmarket/webui-standalone/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/webui-standalone/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/joinmarket-webui/joinmarket-webui-dev-standalone:master
+FROM jam-serve-orderbook-standalone:latest
 
 COPY default.cfg "${DEFAULT_CONFIG}"
 
diff --git a/src/setupProxy.js b/src/setupProxy.js
index bf02f15..9ea938e 100644
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -31,8 +31,8 @@ module.exports = (app) => {
 
   app.use(
     createProxyMiddleware(`${PUBLIC_URL}/obwatch/`, {
-      target: 'http://localhost:62601',
-      pathRewrite: { [`^${PUBLIC_URL}/obwatch/`]: '' },
+      target: 'http://localhost:29080',
+      //pathRewrite: { [`^${PUBLIC_URL}/obwatch/`]: '' },
       changeOrigin: true,
       secure: false,
     })
-- 
2.37.1
```

Requests to the orderbook will then be routed to the secondary container that contains the change and will serve the orderbook via the nginx proxy rules.

Start the regtest setup as normal and view the orderbook. It might take some time for the ob-watcher.py script to complete initialization. If the orderbook is not served as expected immediately, see the obwatcher logs with:
```sh
docker exec -it jm_regtest_joinmarket2 tail -f /root/.joinmarket/logs/obwatch_stdout.log -n 200
```
.. and wait for the following message
```
started http server, visit http://127.0.0.1:62601/
```