### PR TITLE
dev: use debian bullseye as image base

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -48,7 +48,7 @@ RUN git clone "$JM_SERVER_REPO" . --depth=1 --branch "$JM_SERVER_REPO_BRANCH" \
 # --- SERVER builder - end
 
 # --- RUNTIME builder
-FROM python:3.9.10-slim-bullseye
+FROM debian:bullseye-20220801-slim
 ARG MAINTAINER
 ARG JM_SERVER_REPO_REF
 ARG JAM_REPO_REF

--- a/standalone/supervisor-conf/jmwalletd.conf
+++ b/standalone/supervisor-conf/jmwalletd.conf
@@ -1,6 +1,6 @@
 [program:jmwalletd]
 directory=/src/scripts
-command=python jmwalletd.py
+command=python3 jmwalletd.py
 autostart=false
 autorestart=true
 stdout_logfile=/root/.joinmarket/logs/jmwalletd_stdout.log

--- a/standalone/supervisor-conf/ob-watcher.conf
+++ b/standalone/supervisor-conf/ob-watcher.conf
@@ -1,6 +1,6 @@
 [program:ob-watcher]
 directory=/src/scripts/obwatch
-command=python ob-watcher.py --host=127.0.0.1
+command=python3 ob-watcher.py --host=127.0.0.1
 autostart=false
 stdout_logfile=/root/.joinmarket/logs/obwatch_stdout.log
 stdout_logfile_maxbytes=5MB


### PR DESCRIPTION
Uses `debian:bullseye-20220801-slim` instead of `python:3.9.10-slim-bullseye` as base image.
Every needed dependency is installed manually anyway. No functional changes.

This reduces the image size from 731MB to 669MB - still very bulky.
Also, downgrades `python` from `v3.9.10` to the debian repo version, which is `v3.9.2` at the time of writing.

Thinking about pinning all needed versions in a future PR, to adhere to reproducibility.