### PR TITLE
fix: proxy requests to orderbook in ui-only

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ The following environment variables control the configuration
 - `JAM_JMWALLETD_HOST` (required; jmwalletd hostname)
 - `JAM_JMWALLETD_API_PORT` (required; jmwalletd api port)
 - `JAM_JMWALLETD_WEBSOCKET_PORT` (required; jmwalletd websocket port)
+- `JAM_JMOBWATCH_PORT` (required; ob-watcher port)
 
 ### Building Notes
 ```sh
@@ -44,6 +45,7 @@ docker run --rm  -it \
         --env JAM_JMWALLETD_HOST="host.docker.internal" \
         --env JAM_JMWALLETD_API_PORT="28183" \
         --env JAM_JMWALLETD_WEBSOCKET_PORT="28283" \
+        --env JAM_JMOBWATCH_PORT="62601" \
         --publish "8080:80" \
         joinmarket-webui/jam-ui-only
 ```

--- a/ui-only/jam-entrypoint.sh
+++ b/ui-only/jam-entrypoint.sh
@@ -4,6 +4,7 @@ set -eu
 export JAM_JMWALLETD_HOST
 export JAM_JMWALLETD_API_PORT
 export JAM_JMWALLETD_WEBSOCKET_PORT
+export JAM_JMOBWATCH_PORT
 
 # due to `set -u` this fails if variables are not defined
 export JAM_JMWALLETD_API_PROXY
@@ -13,6 +14,10 @@ echo "Will proxy requests for /api/* to ${JAM_JMWALLETD_API_PROXY}/api/*"
 export JAM_JMWALLETD_WEBSOCKET_PROXY
 JAM_JMWALLETD_WEBSOCKET_PROXY="${JAM_JMWALLETD_HOST}:${JAM_JMWALLETD_WEBSOCKET_PORT}"
 echo "Will proxy requests for /jmws to ${JAM_JMWALLETD_WEBSOCKET_PROXY}/"
+
+export JAM_JMOBWATCH_PROXY
+JAM_JMOBWATCH_PROXY="${JAM_JMWALLETD_HOST}:${JAM_JMOBWATCH_PORT}"
+echo "Will proxy requests for /obwatch/* to ${JAM_JMOBWATCH_PROXY}/"
 
 # pass on to the original nginx entry point
 exec /docker-entrypoint.sh "$@"

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -11,6 +11,12 @@ upstream jmwalletd_ws_backend {
     keepalive 2;
 }
 
+upstream obwatch_backend {
+    zone upstreams;
+    server $JAM_JMOBWATCH_PROXY;
+    keepalive 2;
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -66,5 +72,20 @@ server {
         proxy_send_timeout 600s;
 
         proxy_pass https://jmwalletd_ws_backend/;
+    }
+
+    location /obwatch/ {
+        include /etc/nginx/snippets/proxy-params.conf;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        # allow 5 min (default is 60 sec). increase on demand.
+        proxy_read_timeout 300s;
+        # allow 5 min to connect (default is 60 sec)
+        proxy_connect_timeout 300s;
+
+        # must proxy via "http" as ob-watcher does not make use of self-signed cert yet
+        proxy_pass http://obwatch_backend/;
     }
 }


### PR DESCRIPTION
Resolves #54.

Adds a new env variable `JAM_JMOBWATCH_PORT` to be specified when running a `ui-only` docker container.
For simplicity the host will be `JAM_JMWALLETD_HOST`, so `ob-watcher` and `jmwalletd` must run on the same host.
If someone ever wants to run them on different hosts, this can be adapted. For now, this will cover most setups.