### PR TITLE
fix: make sure non-descriptor wallet is created

### DIFF
--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -92,11 +92,28 @@ if [ "${ENSURE_WALLET}" = "true" ]; then
     wallet_name="${jmenv['rpc_wallet_file']}"
 
     echo "Creating wallet $wallet_name if missing..."
-    create_payload="{\"jsonrpc\":\"1.0\",\"id\":\"curl\",\"method\":\"createwallet\",\"params\":[\"${wallet_name}\"]}"
+    create_payload="{\
+        \"jsonrpc\":\"2.0\",\
+        \"id\":\"curl\",\
+        \"method\":\"createwallet\",\
+        \"params\":{\
+            \"wallet_name\":\"${wallet_name}\",\
+            \"descriptors\":false,\
+            \"load_on_startup\":true\
+        }\
+    }"
     curl --silent --user "${btcuser}" --data-binary "${create_payload}" "${btchost}" > /dev/null || true
 
     echo "Loading wallet $wallet_name..."
-    load_payload="{\"jsonrpc\":\"1.0\",\"id\":\"curl\",\"method\":\"loadwallet\",\"params\":[\"${wallet_name}\"]}"
+    load_payload="{\
+        \"jsonrpc\":\"2.0\",\
+        \"id\":\"curl\",\
+        \"method\":\"loadwallet\",\
+        \"params\":{\
+            \"filename\":\"${wallet_name}\",\
+            \"load_on_startup\":true\
+        }\
+    }"
     curl --silent --user "${btcuser}" --data-binary "${load_payload}" "${btchost}" > /dev/null || true
 fi
 


### PR DESCRIPTION
Fixes #57.

Change from jsonrpc 1.0 to 2.0 and add `descriptor=false` to `createwallet` invocation.