### PR TITLE
fix: run tor daemon with distinct user

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -59,7 +59,9 @@ LABEL server-version=$JM_SERVER_REPO_REF
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apt-get update \
+RUN addgroup --system tor \
+    && adduser --system --disabled-login --ingroup tor --gecos 'tor user' tor \
+    && apt-get update \
     && apt-get install -qq --no-install-recommends --no-install-suggests -y gnupg curl apt-transport-https ca-certificates \
     # add nginx debian repo
     && curl --silent https://nginx.org/keys/nginx_signing.key | \
@@ -109,7 +111,7 @@ COPY autostart ${DEFAULT_AUTO_START}
 COPY default.cfg ${DEFAULT_CONFIG}
 COPY supervisor-conf/*.conf /etc/supervisor/conf.d/
 COPY .bashrc /root/.bashrc
-COPY torrc /etc/tor/torrc
+COPY --chown=tor:tor torrc /etc/tor/torrc
 
 COPY nginx/snippets/proxy-params.conf /etc/nginx/snippets/proxy-params.conf
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/standalone/supervisor-conf/tor.conf
+++ b/standalone/supervisor-conf/tor.conf
@@ -1,5 +1,7 @@
 [program:tor]
 command=/usr/sbin/tor -f /etc/tor/torrc
+user=tor
+environment=HOME="/home/tor",USER="tor"
 autostart=false
 stdout_logfile=/var/log/jam/tor_stdout.log
 stdout_logfile_maxbytes=1MB

--- a/standalone/torrc
+++ b/standalone/torrc
@@ -1,6 +1,6 @@
 # Default JoinMarket Tor configuration
-# taken from v0.9.6 on 2022-07-18:
-# https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.6/install.sh#L388-L393
+# taken from v0.9.7 on 2022-08-28:
+# https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.7/install.sh#L429-L433
 Log warn stderr
 SOCKSPort 9050 IsolateDestAddr IsolateDestPort
 ControlPort 9051


### PR DESCRIPTION
Closes #60.

Before this PR the tor daemon ran as user `root`.
After this PR a distinct `tor` user is created and used to start the tor daemon.

Image of this branch is published and can be tested by pulling
`docker pull ghcr.io/joinmarket-webui/jam-dev-standalone:tor-user`