### PR TITLE
feat: randomize mandatory fee config values

### DIFF
--- a/standalone/default.cfg
+++ b/standalone/default.cfg
@@ -216,7 +216,7 @@ max_sweep_fee_change = 0.8
 # market maker for a transaction. Both the limits given in
 # max_cj_fee_abs and max_cj_fee_rel must be exceeded in order
 # to not consider a certain offer.
-max_cj_fee_abs = 300000
+max_cj_fee_abs = 10000
 
 # Maximum relative coinjoin fee, in fractions of the coinjoin value
 # e.g. if your coinjoin amount is 2 btc (200 million satoshi) and

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -45,6 +45,12 @@ done < <(env -0)
 # ensure a wallet name is present
 jmenv['rpc_wallet_file']=${jmenv['rpc_wallet_file']:-'jm_webui_default'}
 
+# make sure `max_cj_fee_abs` and `max_cj_fee_rel` are set
+# `max_cj_fee_abs` between 5000 - 10000 sats if not provided
+jmenv['max_cj_fee_abs']=${jmenv['max_cj_fee_abs']:-"$(shuf -i 5000-10000 -n1)"}
+# `max_cj_fee_rel` between 0.01 - 0.03% if not provided
+jmenv['max_cj_fee_rel']=${jmenv['max_cj_fee_rel']:-"0.000$((RANDOM%3+1))"}
+
 # adapt 'blockchain_source' if missing and we're in regtest mode
 if [ "${jmenv['network']}" = "regtest" ] && [ "${jmenv['blockchain_source']}" = "" ]; then
     jmenv['blockchain_source']='regtest'


### PR DESCRIPTION
Resolves #65.

Randomizes `max_cj_fee_abs` and `max_cj_fee_rel` if not provided.
- `max_cj_fee_abs` between 5k - 10k sats
- `max_cj_fee_rel` to 0.01%, 0.02% or  0.03%

Approach is taken from RaspiBlitz PR for Jam: https://github.com/rootzoll/raspiblitz/blob/fe2619a8e60d7277192e1e01231721a26d5ca705/home.admin/config.scripts/bonus.jam.sh#L218-L220
Special thanks to @openoms!