### PR TITLE
fix: ensure jm working dir exists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,11 +102,13 @@ docker run --rm  -it \
         --add-host=host.docker.internal:host-gateway \
         --env APP_USER="joinmarket" \
         --env APP_PASSWORD="joinmarket" \
+        --env ENSURE_WALLET="true" \
         --env JM_RPC_HOST="host.docker.internal" \
         --env JM_RPC_PORT="18443" \
         --env JM_RPC_USER="jm" \
         --env JM_RPC_PASSWORD="***" \
         --env JM_NETWORK="regtest" \
+        --volume jmdatadir:/root/.joinmarket \
         --publish "8080:80" \
         joinmarket-webui/jam-standalone
 ```

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ The following environment variables control the configuration
 - `RESTORE_DEFAULT_CONFIG` (optional; overwrites any existing `joinmarket.cfg` file the container's default config on startup)
 
 Variables starting with prefix `JM_` will be applied to `joinmarket.cfg` e.g.:
-- `jm_gaplimit: 2000` will set the `gaplimit` config value to `2000`
+- `JM_GAPLIMIT: 2000` will set the `gaplimit` config value to `2000`
 
 ### Building Notes
 ```sh
@@ -100,14 +100,16 @@ docker run --rm --entrypoint="/bin/bash" -it joinmarket-webui/jam-standalone
 ```sh
 docker run --rm  -it \
         --add-host=host.docker.internal:host-gateway \
-        --env APP_USER="joinmarket" \
-        --env APP_PASSWORD="joinmarket" \
-        --env ENSURE_WALLET="true" \
         --env JM_RPC_HOST="host.docker.internal" \
         --env JM_RPC_PORT="18443" \
         --env JM_RPC_USER="jm" \
         --env JM_RPC_PASSWORD="***" \
         --env JM_NETWORK="regtest" \
+        --env APP_USER="joinmarket" \
+        --env APP_PASSWORD="joinmarket" \
+        --env ENSURE_WALLET="true" \
+        --env REMOVE_LOCK_FILES="true" \
+        --env RESTORE_DEFAULT_CONFIG="true" \
         --volume jmdatadir:/root/.joinmarket \
         --publish "8080:80" \
         joinmarket-webui/jam-standalone

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -e
 
-# ensure 'log' directory exists
+# ensure jm working directory exists
+mkdir --parents "${DATADIR}/"
+
+# ensure log directory exists
 mkdir --parents /var/log/jam
 
 # restore the default config

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -110,4 +110,4 @@ if [ "${ENSURE_WALLET}" = "true" ]; then
 fi
 
 
-exec supervisord
+exec supervisord --configuration /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Fix for missing jm working directory if it is not mapped to the host system.

The log feature introduced a regression bug, when the logs moved from directory `$JM_WORK_DIR/logs` to `/var/log/jam`.
Since then, it was not ensured that the directory actually exists.

In most setups this is no problem, as the directory will most probably always be mapped to the host system via `--volume jmdatadir:/root/.joinmarket`, but in some situation, e.g. just starting the image once, this might lead to an error when the config file is copied: `cp: cannot create regular file '/root/.joinmarket/joinmarket.cfg': No such file or directory`.

The added line `mkdir --parents "${DATADIR}/"` now creates the directory in case it is missing.

Small additional change: In order to prevent supervisord from searching for its configuration file in multiple locations and printing a warning message to stdout, the path to the config file is passed as a parameter.