### PR TITLE
deps(workflow): update github actions to newest versions

### DIFF
--- a/.github/workflows/check-and-update-dependencies.yml
+++ b/.github/workflows/check-and-update-dependencies.yml
@@ -17,11 +17,11 @@ jobs:
       server_repo_ref: ${{ steps.dotenv.outputs.jm_server_repo_ref }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Read .env file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@v1.0.0
         with:
           log-variables: true
 

--- a/.github/workflows/create-and-publish-docker-on-release.yml
+++ b/.github/workflows/create-and-publish-docker-on-release.yml
@@ -15,11 +15,11 @@ jobs:
       server_repo_ref: ${{ steps.dotenv.outputs.jm_server_repo_ref }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Read .env file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@v1.0.0
         with:
           log-variables: true
 

--- a/.github/workflows/create-and-publish-docker.yml
+++ b/.github/workflows/create-and-publish-docker.yml
@@ -8,11 +8,11 @@ on:
         required: true
         type: string
       ui_repo_ref:
-        description: 'ui version/branch (e.g. v0.0.10, master, etc.)'
+        description: 'ui version/branch (e.g. v0.1.1, master, etc.)'
         required: true
         type: string
       server_repo_ref:
-        description: 'server version/branch (e.g. v0.9.6, master, etc.)'
+        description: 'server version/branch (e.g. v0.9.8, master, etc.)'
         required: true
         type: string
       image_name_prefix:
@@ -34,19 +34,19 @@ jobs:
          context: [ui-only,standalone]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1.6.0
+        uses: docker/setup-buildx-action@v2.2.1
         with:
           install: true
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1.12.0
+        uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3.6.2
+        uses: docker/metadata-action@v4.1.1
         with:
           images: ${{ env.REGISTRY }}/${{ inputs.image_name_prefix }}${{ matrix.context }}
           labels: |
@@ -62,7 +62,7 @@ jobs:
             org.opencontainers.image.version=${{ inputs.version }}
 
       - name: Build and push Docker image for ${{ matrix.context }}
-        uses: docker/build-push-action@v2.8.0
+        uses: docker/build-push-action@v3.2.0
         with:
           context: ./${{ matrix.context }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/update-dependency-version.yml
+++ b/.github/workflows/update-dependency-version.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
     
       # Parse the repo url (e.g. "https://github.com/bitcoin/bips") and extract:
       # - the full repo name (e.g. "bitcoin/bips")
@@ -55,7 +55,7 @@ jobs:
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           NAME: ${{ steps.repoinfo.outputs.name_short }}
           LINK: ${{ inputs.repo_url }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           add-paths: .env
           branch: ${{ env.NAME }}-updates


### PR DESCRIPTION
Partly addresses #70.

These changes only affect github workflows. No changes to the image itself are made.

Warnings when building current `master` branch: https://github.com/joinmarket-webui/jam-docker/actions/runs/3298111040
Fixed (no more warnings) in this branch: https://github.com/joinmarket-webui/jam-docker/actions/runs/3297407397