### PR TITLE
Remove unnecessary steps in building dinit

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -46,8 +46,6 @@ WORKDIR /usr/src/dinit
 
 # checkout and build project
 RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.16.0" \
-    && chmod +x ./configs/mconfig.Linux.sh \
-    && ./configs/mconfig.Linux.sh \
     && make \
     && export ASAN_OPTIONS=detect_leaks=0 \
     && make check \


### PR DESCRIPTION
Hi!
mconfig scripts runs in a part of `make` command so we don't need to run that separately.
https://github.com/davmac314/dinit/blob/e679e6f50b43210863072e97d7f708c9fdb95dd0/Makefile#L30-L41

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`