### PR TITLE
feat: wait for bitcoind to accept RPC calls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,10 +66,11 @@ docker pull ghcr.io/joinmarket-webui/jam-standalone:latest
 The following environment variables control the configuration
 - `APP_USER` (optional; username used for basic authentication)
 - `APP_PASSWORD` (optional, but required if `APP_USER` is provided; password used for basic authentication)
-- `ENSURE_WALLET` (optional; create and load the wallet in bitcoin core on startup)
+- `ENSURE_WALLET` (optional, defaults to `false`; create and load the wallet in bitcoin core on startup)
 - `READY_FILE` (optional; wait for a file to be created before starting all services, e.g. to wait for chain synchronization)
-- `REMOVE_LOCK_FILES` (optional; remove leftover lockfiles from possible unclean shutdowns on startup)
-- `RESTORE_DEFAULT_CONFIG` (optional; overwrites any existing `joinmarket.cfg` file the container's default config on startup)
+- `REMOVE_LOCK_FILES` (optional, defaults to `false`; remove leftover lockfiles from possible unclean shutdowns on startup)
+- `RESTORE_DEFAULT_CONFIG` (optional, defaults to `false`; overwrites any existing `joinmarket.cfg` file with a default config)
+- `WAIT_FOR_BITCOIND` (optional, defaults to `true`; wait for bitcoind to accept RPC request and report >= 100 blocks)
 
 Variables starting with prefix `JM_` will be applied to `joinmarket.cfg` e.g.:
 - `JM_GAPLIMIT: 2000` will set the `gaplimit` config value to `2000`
@@ -110,6 +111,7 @@ docker run --rm  -it \
         --env ENSURE_WALLET="true" \
         --env REMOVE_LOCK_FILES="true" \
         --env RESTORE_DEFAULT_CONFIG="true" \
+        --env WAIT_FOR_BITCOIND="true" \
         --volume jmdatadir:/root/.joinmarket \
         --publish "8080:80" \
         joinmarket-webui/jam-standalone

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -95,7 +95,7 @@ RUN addgroup --system tor \
     && apt-get update \
     && apt-get install -qq --no-install-recommends --no-install-suggests -y \
     # image dependencies
-    tini iproute2 procps vim \
+    tini iproute2 procps vim jq \
     # servers dependencies (see `install.sh`)
     build-essential automake pkg-config libtool libltdl-dev python3-dev python3-setuptools python3-pip \
     # tor

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -96,7 +96,7 @@ if [ "${WAIT_FOR_BITCOIND}" != "false" ]; then
     }"
     # generally only testing for a non-error response would be enough, but 
     # waiting for blocks >= 100 is needed for regtest environments as well!
-    until curl --silent --user "${btcuser}" --data-binary "${getblockchaininfo_payload}" "${btchost}" | jq -e ".result.blocks >= 100" > /dev/null 2>&1
+    until curl --silent --show-error --user "${btcuser}" --data-binary "${getblockchaininfo_payload}" "${btchost}" 2>&1 | jq -e ".result.blocks >= 100" > /dev/null 2>&1
     do
         sleep 5
     done


### PR DESCRIPTION
Resolves #75.

This PR enables waiting for the backing Bitcoin Core instance to be ready and accept RPC requests.

This is done by making a `getblockchaininfo` request before starting any services, as this is the first request JM will be performing during initialization. Also, as a by-product, the response is used to wait for `>= 100` blocks to be reported - thereby making the image `regtest`-compatible without further adaptions.

This behaviour can be disabled by setting env var `WAIT_FOR_BITCOIND` to `false`. Default value is `true`.

Please see this as a quick bugfix and not the final solution. Ideally, only service s`jmwalletd` and `ob-watcher` are waiting. Other services (such as `nginx` and `tor`) could already be started.

## How to test?

Please see https://github.com/joinmarket-webui/jam/pull/559 and follow the instructions.