### PR TITLE
config: recreate config according to JM v0.9.9

### DIFF
--- a/standalone/default.cfg
+++ b/standalone/default.cfg
@@ -378,7 +378,7 @@ tor_control_port = 9051
 # (note the *virtual port*, that the client uses,
 # is hardcoded to 80):
 onion_serving_host = 127.0.0.1
-onion_serving_port = 8080
+onion_serving_port = 8082
 
 # in some exceptional case the HS may be SSL configured,
 # this feature is not yet implemented in code, but here for the

--- a/standalone/default.cfg
+++ b/standalone/default.cfg
@@ -80,7 +80,7 @@ hidden_service_dir =
 # Each item has format host:port ; both are required, though port will
 # be 5222 if created in this code.
 # for MAINNET:
-directory_nodes = 3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,jmdirjmioywe2s5jad7ts6kgcqg66rj6wujj6q77n6wbdrgocqwexzid.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222
+directory_nodes = g3hv4uynnmynqqq2mchf3fcm3yd46kfzmcdogejuckgwknwyq5ya6iad.onion:5222,3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222
 
 # for SIGNET (testing network):
 # directory_nodes = rr6f6qtleiiwic45bby4zwmiwjrj3jsbmcvutwpqxjziaydjydkk5iad.onion:5222,k74oyetjqgcamsyhlym2vgbjtvhcrbxr4iowd4nv4zk5sehw4v665jad.onion:5222,y2ruswmdbsfl4hhwwiqz4m3sx6si5fr6l3pf62d4pms2b53wmagq3eqd.onion:5222


### PR DESCRIPTION
Updates config property `directory_nodes` as per https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/ebdbac7e9855bedc2627fc5ad71630973901202d

