### PR TITLE
fix(actions): replace deprecated operations 

### DIFF
--- a/.github/workflows/check-and-update-dependencies.yml
+++ b/.github/workflows/check-and-update-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Read .env file
         id: dotenv
-        uses: falti/dotenv-action@v1.0.0
+        uses: falti/dotenv-action@v1.0.2
         with:
           log-variables: true
 

--- a/.github/workflows/create-and-publish-docker-on-release.yml
+++ b/.github/workflows/create-and-publish-docker-on-release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Read .env file
         id: dotenv
-        uses: falti/dotenv-action@v1.0.0
+        uses: falti/dotenv-action@v1.0.2
         with:
           log-variables: true
 

--- a/.github/workflows/update-dependency-version.yml
+++ b/.github/workflows/update-dependency-version.yml
@@ -31,15 +31,15 @@ jobs:
         env:
           REPO_URL: ${{ inputs.repo_url }}
         run: |
-          echo ::set-output name=name::$(echo ${REPO_URL#*://*/})
-          echo ::set-output name=name_short::$(echo ${REPO_URL##*://*/})
+          echo "{name}={$(echo ${REPO_URL#*://*/})}" >> $GITHUB_OUTPUT
+          echo "{name_short}={$(echo ${REPO_URL##*://*/})}" >> $GITHUB_OUTPUT
 
       - name: Get Latest Releases
         id: versions
         env:
           REPO_NAME: ${{ steps.repoinfo.outputs.name }}
         run: |
-          echo ::set-output name=release_tag::$(curl -sL "https://api.github.com/repos/${REPO_NAME}/releases/latest" | jq -r ".tag_name")
+          echo "{release_tag}={$(curl -sL "https://api.github.com/repos/${REPO_NAME}/releases/latest" | jq -r ".tag_name")}" >> $GITHUB_OUTPUT
 
       - name: Update Environment Variable
         if: inputs.current_tag != steps.versions.outputs.release_tag
@@ -50,7 +50,7 @@ jobs:
           sed -i "s/^$ENV_VARNAME=.*/$ENV_VARNAME=$RELEASE_TAG/g" .env
 
       - name: Create Pull Request
-        if: inputs.current_tag != steps.versions.outputs.release_tag
+        if: steps.versions.outputs.release_tag != '' && inputs.current_tag != steps.versions.outputs.release_tag
         env:
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           NAME: ${{ steps.repoinfo.outputs.name_short }}


### PR DESCRIPTION
Closes #70.
Closes #82.

Compare the two runs before and after the changes:
Before: https://github.com/joinmarket-webui/jam-docker/actions/runs/4003577079 (branch `master`)
After: https://github.com/joinmarket-webui/jam-docker/actions/runs/4006221672 (branch `fix/workflow-set-output`)

Deadline for merging this is [31st May, 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

The deprecation warnings are fixed. However, if it _really_ works as expected, will only be known after a new JM or Jam release.