### PR TITLE
fix(build): install python3-venv

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -97,7 +97,7 @@ RUN addgroup --system tor \
     # image dependencies
     tini iproute2 procps vim jq \
     # servers dependencies (see `install.sh`)
-    build-essential automake pkg-config libtool libltdl-dev python3-dev python3-setuptools python3-pip \
+    build-essential automake pkg-config libtool libltdl-dev python3-dev python3-pip python3-setuptools python3-venv \
     # tor
     tor \
     deb.torproject.org-keyring \


### PR DESCRIPTION
See https://github.com/joinmarket-webui/jam/pull/585 and https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1396#issuecomment-1370536920 for more information.
This is required to successfully build JM `v0.9.9` - should not be needed as build arg `--docker-install` is used.. However, without it, it does not work and exits with:
```
Package python3-venv is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'python3-venv' has no installation candidate
Dependecies could not be installed. Exiting.
The command '/bin/bash -o pipefail -c ./install.sh --docker-install --without-qt     && rm --recursive --force install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop' returned a non-zero code: 1
```

With this change applied, the build is successful.
Hope this can be removed in the future.

Edit: lmao.. please ignore the typo in the branch name :sweat_smile: 