### PR TITLE
build(deps): update dinit from v0.16.0 to v0.16.1

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update \
 WORKDIR /usr/src/dinit
 
 # checkout and build project
-RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.16.0" \
+# see: https://github.com/davmac314/dinit/releases
+RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.16.1" \
     && make \
     && export ASAN_OPTIONS=detect_leaks=0 \
     && make check \


### PR DESCRIPTION
This PR updates [`dinit`](https://github.com/davmac314/dinit) from `v0.16.0` to `v0.16.1`.

See the changes here: https://github.com/davmac314/dinit/releases/tag/v0.16.1