### PR TITLE
build: simplify git repo checkout

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,5 @@
 JAM_REPO=https://github.com/joinmarket-webui/jam
-JAM_REPO_BRANCH=master
 JAM_REPO_REF=v0.1.5
 
 JM_SERVER_REPO=https://github.com/JoinMarket-Org/joinmarket-clientserver
-JM_SERVER_REPO_BRANCH=master
 JM_SERVER_REPO_REF=v0.9.9

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,6 @@ docker build --label "local" \
 
 #### Build args
 - `JAM_REPO` (ui git repo; defaults to `https://github.com/joinmarket-webui/jam`)
-- `JAM_REPO_BRANCH` (ui git branch; defaults to `master`)
 - `JAM_REPO_REF` (ui git ref; defaults to `master`)
 
 ### Inspecting the Container
@@ -85,11 +84,9 @@ docker build --label "local" \
 
 #### Build args
 - `JAM_REPO` (ui git repo; defaults to `https://github.com/joinmarket-webui/jam`)
-- `JAM_REPO_BRANCH` (ui git branch; defaults to `master`)
 - `JAM_REPO_REF` (ui git ref; defaults to `master`)
 ---
 - `JM_SERVER_REPO` (server git repo; defaults to `https://github.com/JoinMarket-Org/joinmarket-clientserver`)
-- `JM_SERVER_REPO_BRANCH` (server git branch; defaults to `master`)
 - `JM_SERVER_REPO_REF` (server git ref; defaults to `master`)
 
 ### Inspecting the Container

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -3,11 +3,9 @@
 ARG MAINTAINER='Jam https://github.com/joinmarket-webui'
 
 ARG JAM_REPO=https://github.com/joinmarket-webui/jam
-ARG JAM_REPO_BRANCH=master
 ARG JAM_REPO_REF=master
 
 ARG JM_SERVER_REPO=https://github.com/JoinMarket-Org/joinmarket-clientserver
-ARG JM_SERVER_REPO_BRANCH=master
 ARG JM_SERVER_REPO_REF=master
 
 # --- Builder base 
@@ -18,7 +16,6 @@ RUN apk add --no-cache --update git
 # --- UI builder 
 FROM builder-base AS ui-builder
 ARG JAM_REPO
-ARG JAM_REPO_BRANCH
 ARG JAM_REPO_REF
 
 # install build dependencies
@@ -27,9 +24,7 @@ RUN apk add --no-cache --update nodejs npm
 WORKDIR /usr/src/jam
 
 # checkout and build project
-RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_BRANCH" \
-    && git fetch --all --tags \
-    && git checkout "$JAM_REPO_REF" \
+RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
     && npm install --no-fund --no-audit \
     && npm run build
 # --- UI builder - end
@@ -57,14 +52,11 @@ RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.16.0
 # --- SERVER builder
 FROM builder-base AS server-builder
 ARG JM_SERVER_REPO
-ARG JM_SERVER_REPO_BRANCH
 ARG JM_SERVER_REPO_REF
 
 WORKDIR /usr/src/joinmarket-clientserver
 
-RUN git clone "$JM_SERVER_REPO" . --depth=1 --branch "$JM_SERVER_REPO_BRANCH" \
-    && git fetch --all --tags \
-    && git checkout "$JM_SERVER_REPO_REF"
+RUN git clone "$JM_SERVER_REPO" . --depth=1 --branch "$JM_SERVER_REPO_REF"
 # --- SERVER builder - end
 
 # --- RUNTIME builder

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -3,7 +3,6 @@
 ARG MAINTAINER='Jam https://github.com/joinmarket-webui'
 
 ARG JAM_REPO=https://github.com/joinmarket-webui/jam
-ARG JAM_REPO_BRANCH=master
 ARG JAM_REPO_REF=master
 
 FROM alpine:3.16.2 AS builder-base
@@ -13,15 +12,12 @@ RUN apk add --no-cache --update git nodejs npm
 # ---
 FROM builder-base AS builder
 ARG JAM_REPO
-ARG JAM_REPO_BRANCH
 ARG JAM_REPO_REF
 
 WORKDIR /usr/src/app
 
 # checkout and build project
-RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_BRANCH" \
-    && git fetch --all --tags \
-    && git checkout "$JAM_REPO_REF" \
+RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
     && npm install --no-fund --no-audit \
     && npm run build
 


### PR DESCRIPTION
Removes unneeded environment variables `JAM_REPO_BRANCH` and `JM_SERVER_REPO_BRANCH`.
I cannot remember exactly what the reasoning behind these additional variables was, but they seem redundant now as `--branch` arg of `git clone` can checkout branches as well as tags.

This should slightly speed up the initial repo checkout when building the images, albeit maybe unnoticeable.