### PR TITLE
chore(config): move 'gaplimit' to section 'POLICY'

### DIFF
--- a/standalone/default.cfg
+++ b/standalone/default.cfg
@@ -169,6 +169,11 @@ native = true
 # but don't forget to bump your miner fees!
 merge_algorithm = default
 
+# Used currently by the RPC to modify the gap limit
+# for address searching during wallet sync. Command line
+# scripts can use the command line flag `-g` instead.
+gaplimit = 6
+
 # The fee estimate is based on a projection of how many sats/kilo-vbyte
 # are needed to get in one of the next N blocks. N is set here as
 # the value of 'tx_fees'. This cost estimate is high if you set
@@ -410,8 +415,6 @@ minsize = 100000
 
 # [fraction, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
 size_factor = 0.1
-
-gaplimit = 6
 
 [SNICKER]
 # Any other value than 'true' will be treated as False,


### PR DESCRIPTION
Moves the `gaplimit` config variable from section `YIELDGENERATOR` to `POLICY` according to [joinmarket-clientserver#1525](https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1525).

Please only merge once the above PR is applied and/or a new JM version has been released.