### PR TITLE
build(deps): update dinit from v0.16.1 to v0.18.0

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /usr/src/dinit
 
 # checkout and build project
 # see: https://github.com/davmac314/dinit/releases
-RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.17.0" \
+RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.18.0" \
     && make \
     && export ASAN_OPTIONS=detect_leaks=0 \
     && make check \

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /usr/src/dinit
 
 # checkout and build project
 # see: https://github.com/davmac314/dinit/releases
-RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.16.1" \
+RUN git clone "https://github.com/davmac314/dinit" . --depth=1 --branch "v0.17.0" \
     && make \
     && export ASAN_OPTIONS=detect_leaks=0 \
     && make check \

--- a/standalone/dinit-conf/jmwalletd
+++ b/standalone/dinit-conf/jmwalletd
@@ -6,3 +6,5 @@ restart = true
 smooth-recovery = true
 start-timeout = 10
 logfile = /var/log/jam/jmwalletd_stdout.log
+logfile-gid = nginx
+logfile-permissions = 640

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -7,9 +7,6 @@ mkdir --parents "${DATADIR}/"
 # ensure log directory exists
 mkdir --parents /var/log/jam
 
-# touch jmwalletd log file to preserve read permissions for nginx (644)
-touch /var/log/jam/jmwalletd_stdout.log
-
 # restore the default config
 if [ ! -f "$CONFIG" ] || [ "${RESTORE_DEFAULT_CONFIG}" = "true" ]; then
     cp --force "$DEFAULT_CONFIG" "$CONFIG"


### PR DESCRIPTION
Update `dinit` from v0.16.1 to v0.18.0.
See https://github.com/davmac314/dinit/releases/tag/v0.18.0 for more information.

Log file permission handling has been slightly adapted. From the changelog (0.17.x):
> New service settings to control service logfile ownership and permissions: logfile-permissions, the logfile ownership and permissions are now always set).

Before, the default was to preserve the permissions on the log file if it already exists. Now, without the changes in this PR the `jmwalletd_stdout.log` file permissions would be `600`, making it non-readable for user `nginx`.
