### PR TITLE
build(deps): update base containers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,12 +40,24 @@ docker run --rm --entrypoint="/bin/ash" -it joinmarket-webui/jam-ui-only
 ### Run
 ```sh
 docker run --rm  -it \
-        --add-host=host.docker.internal:host-gateway \
+        --add-host host.docker.internal:host-gateway \
         --env JAM_JMWALLETD_HOST="host.docker.internal" \
         --env JAM_JMWALLETD_API_PORT="28183" \
         --env JAM_JMWALLETD_WEBSOCKET_PORT="28283" \
         --env JAM_JMOBWATCH_PORT="62601" \
         --publish "8080:80" \
+        joinmarket-webui/jam-ui-only
+```
+
+or (using the host network)
+
+```sh
+docker run --rm  -it \
+        --network host \
+        --env JAM_JMWALLETD_HOST="localhost" \
+        --env JAM_JMWALLETD_API_PORT="28183" \
+        --env JAM_JMWALLETD_WEBSOCKET_PORT="28283" \
+        --env JAM_JMOBWATCH_PORT="62601" \
         joinmarket-webui/jam-ui-only
 ```
 
@@ -97,7 +109,7 @@ docker run --rm --entrypoint="/bin/bash" -it joinmarket-webui/jam-standalone
 ### Run
 ```sh
 docker run --rm  -it \
-        --add-host=host.docker.internal:host-gateway \
+        --add-host host.docker.internal:host-gateway \
         --env JM_RPC_HOST="host.docker.internal" \
         --env JM_RPC_PORT="18443" \
         --env JM_RPC_USER="jm" \

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -9,7 +9,7 @@ ARG JM_SERVER_REPO=https://github.com/JoinMarket-Org/joinmarket-clientserver
 ARG JM_SERVER_REPO_REF=master
 
 # --- Builder base 
-FROM alpine:3.16.2 AS builder-base
+FROM alpine:3.18.3 AS builder-base
 RUN apk add --no-cache --update git
 # --- Builder base - end
 

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
 
 
 # --- dinit builder
-FROM debian:bullseye-20221004-slim AS dinit-builder
+FROM debian:bullseye-20230919-slim AS dinit-builder
 
 # install build dependencies
 RUN apt-get update \
@@ -61,7 +61,7 @@ RUN git clone "$JM_SERVER_REPO" . --depth=1 --branch "$JM_SERVER_REPO_REF"
 # --- SERVER builder - end
 
 # --- RUNTIME builder
-FROM debian:bullseye-20221004-slim
+FROM debian:bullseye-20230919-slim
 ARG MAINTAINER
 ARG JM_SERVER_REPO_REF
 ARG JAM_REPO_REF

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -5,7 +5,7 @@ ARG MAINTAINER='Jam https://github.com/joinmarket-webui'
 ARG JAM_REPO=https://github.com/joinmarket-webui/jam
 ARG JAM_REPO_REF=master
 
-FROM alpine:3.16.2 AS builder-base
+FROM alpine:3.18.3 AS builder-base
 # install build dependencies
 RUN apk add --no-cache --update git nodejs npm
 

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
     && npm run build
 
 # ---
-FROM nginx:1.23.1-alpine as runtime
+FROM nginx:1.25.2-alpine3.18 as runtime
 
 # ---
 FROM runtime


### PR DESCRIPTION
- update `debian:bullseye` from `20221004` to `20230919`
- update `alpine` from `v3.16.2` to `v3.18.3`
- update `nginx` from `v1.23.1` to `v1.25.2`
