### PR TITLE
build(deps): update dependencies

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -9,7 +9,7 @@ ARG JM_SERVER_REPO=https://github.com/JoinMarket-Org/joinmarket-clientserver
 ARG JM_SERVER_REPO_REF=master
 
 # --- Builder base 
-FROM alpine:3.18.3 AS builder-base
+FROM alpine:3.19.1 AS builder-base
 RUN apk add --no-cache --update git
 # --- Builder base - end
 

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
 
 
 # --- dinit builder
-FROM debian:bullseye-20230919-slim AS dinit-builder
+FROM debian:bullseye-20240211-slim AS dinit-builder
 
 # install build dependencies
 RUN apt-get update \
@@ -61,7 +61,7 @@ RUN git clone "$JM_SERVER_REPO" . --depth=1 --branch "$JM_SERVER_REPO_REF"
 # --- SERVER builder - end
 
 # --- RUNTIME builder
-FROM debian:bullseye-20230919-slim
+FROM debian:bullseye-20240211-slim
 ARG MAINTAINER
 ARG JM_SERVER_REPO_REF
 ARG JAM_REPO_REF

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
     && npm run build
 
 # ---
-FROM nginx:1.25.2-alpine3.18 as runtime
+FROM nginx:1.25.4-alpine3.18-slim as runtime
 
 # ---
 FROM runtime

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -5,7 +5,7 @@ ARG MAINTAINER='Jam https://github.com/joinmarket-webui'
 ARG JAM_REPO=https://github.com/joinmarket-webui/jam
 ARG JAM_REPO_REF=master
 
-FROM alpine:3.18.3 AS builder-base
+FROM alpine:3.19.1 AS builder-base
 # install build dependencies
 RUN apk add --no-cache --update git nodejs npm
 


### PR DESCRIPTION
Updates:
- alpine from v3.18.3 to v3.19.1
- nginx from v1.25.2-alpine3.18 to v1.25.4-alpine318-slim (ui-only)
- debian from bullseye-20230919-slim to bullseye-20240211-slim

:heavy_check_mark: Successful tests in network `regtest`.