### PR TITLE
fix(nginx): increase upstreams shared memory size

### DIFF
--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -1,6 +1,6 @@
 
 upstream jmwalletd_api_backend {
-    zone upstreams 64K;
+    zone upstreams 256K;
     server 127.0.0.1:28183;
     keepalive 16;
 }


### PR DESCRIPTION
Resolves #123.

Increases the shared memory zone size from 64k to 256k.
This should fix problems reported by users on umbrelOS 1.x.
