### PR TITLE
build(docker): build with specific node version

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -8,8 +8,14 @@ ARG JAM_REPO_REF=master
 ARG JM_SERVER_REPO=https://github.com/JoinMarket-Org/joinmarket-clientserver
 ARG JM_SERVER_REPO_REF=master
 
+ARG NODE_VERSION=22.3.0
+ARG ALPINE_VERSION=3.19.1
+ARG DEBIAN_VERSION=bullseye-20240211-slim
+
+FROM node:${NODE_VERSION}-alpine AS node
+
 # --- Builder base 
-FROM alpine:3.19.1 AS builder-base
+FROM alpine:${ALPINE_VERSION} AS builder-base
 RUN apk add --no-cache --update git
 # --- Builder base - end
 
@@ -18,8 +24,10 @@ FROM builder-base AS ui-builder
 ARG JAM_REPO
 ARG JAM_REPO_REF
 
-# install build dependencies
-RUN apk add --no-cache --update nodejs npm
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
 
 WORKDIR /usr/src/jam
 
@@ -31,7 +39,7 @@ RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
 
 
 # --- dinit builder
-FROM debian:bullseye-20240211-slim AS dinit-builder
+FROM debian:${DEBIAN_VERSION} AS dinit-builder
 
 # install build dependencies
 RUN apt-get update \
@@ -61,7 +69,7 @@ RUN git clone "$JM_SERVER_REPO" . --depth=1 --branch "$JM_SERVER_REPO_REF"
 # --- SERVER builder - end
 
 # --- RUNTIME builder
-FROM debian:bullseye-20240211-slim
+FROM debian:${DEBIAN_VERSION}
 ARG MAINTAINER
 ARG JM_SERVER_REPO_REF
 ARG JAM_REPO_REF

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -104,10 +104,10 @@ COPY --from=dinit-builder /usr/src/dinit/dinit-bin/sbin /sbin
 COPY --from=ui-builder /usr/src/jam/build /app
 COPY --from=server-builder /usr/src/joinmarket-clientserver /src
 
-ENV DATADIR /root/.joinmarket
-ENV CONFIG ${DATADIR}/joinmarket.cfg
-ENV DEFAULT_CONFIG /root/default.cfg
-ENV PATH /src/scripts:$PATH
+ENV DATADIR=/root/.joinmarket
+ENV CONFIG=${DATADIR}/joinmarket.cfg
+ENV DEFAULT_CONFIG=/root/default.cfg
+ENV PATH=/src/scripts:$PATH
 
 WORKDIR /src
 

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone "$JAM_REPO" . --depth=1 --branch "$JAM_REPO_REF" \
     && npm run build
 
 # ---
-FROM nginx:1.25.4-alpine3.18-slim as runtime
+FROM nginx:1.25.4-alpine3.18-slim AS runtime
 
 # ---
 FROM runtime

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -5,9 +5,20 @@ ARG MAINTAINER='Jam https://github.com/joinmarket-webui'
 ARG JAM_REPO=https://github.com/joinmarket-webui/jam
 ARG JAM_REPO_REF=master
 
-FROM alpine:3.19.1 AS builder-base
+ARG NODE_VERSION=22.3.0
+ARG ALPINE_VERSION=3.19.1
+
+FROM node:${NODE_VERSION}-alpine AS node
+
+FROM alpine:${ALPINE_VERSION} AS builder-base
+
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
+
 # install build dependencies
-RUN apk add --no-cache --update git nodejs npm
+RUN apk add --no-cache --update git
 
 # ---
 FROM builder-base AS builder


### PR DESCRIPTION
In order to fix the timeout issues in CI, this change adds the ability to specify the node version (and hence, the npm version) during the docker build. Newer npm versions should behave better during `npm install` and do not open as many connections as before, which might be the culprit on the timeouts in the CI builds.

## How to test
Please build ui-only and standalone images and verify that everything is working as expected:
```shell
docker build --label "local" \
        --build-arg JAM_REPO_REF=master \
        --tag "joinmarket-webui/jam-ui-only" ./ui-only
```
```shell
docker build --label "local" \
        --build-arg JAM_REPO_REF=master \
        --build-arg JM_SERVER_REPO_REF=master \
        --tag "joinmarket-webui/jam-standalone" ./standalone
```