### PR TITLE
chore: recreate default config

### DIFF
--- a/justfile
+++ b/justfile
@@ -82,3 +82,7 @@ extract-default-config:
     @docker exec -it jam-dev-create-config cat /root/.joinmarket/joinmarket.cfg > standalone/default.cfg
     @echo "Stopping docker container..."
     @docker stop jam-dev-create-config
+
+[group("development")]
+probe-directory-node onion_url port='5222':
+    @curl --verbose --proxy socks5h://localhost:9050 {{onion_url}}:{{port}}

--- a/standalone/default.cfg
+++ b/standalone/default.cfg
@@ -81,7 +81,6 @@ hidden_service_dir =
 # be 5222 if created in this code.
 # for MAINNET:
 directory_nodes = g3hv4uynnmynqqq2mchf3fcm3yd46kfzmcdogejuckgwknwyq5ya6iad.onion:5222,3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222,odpwaf67rs5226uabcamvypg3y4bngzmfk7255flcdodesqhsvkptaid.onion:5222
-
 # for SIGNET (testing network):
 # directory_nodes = rr6f6qtleiiwic45bby4zwmiwjrj3jsbmcvutwpqxjziaydjydkk5iad.onion:5222,k74oyetjqgcamsyhlym2vgbjtvhcrbxr4iowd4nv4zk5sehw4v665jad.onion:5222,y2ruswmdbsfl4hhwwiqz4m3sx6si5fr6l3pf62d4pms2b53wmagq3eqd.onion:5222
 
@@ -89,54 +88,22 @@ directory_nodes = g3hv4uynnmynqqq2mchf3fcm3yd46kfzmcdogejuckgwknwyq5ya6iad.onion
 # running multiple bots at once. Don't alter it otherwise
 regtest_count = 0,0
 
-## IRC SERVER 1: Darkscience IRC (Tor, IP)
-################################################################################
-[MESSAGING:server1]
-# by default the legacy format without a `type` field is
-# understood to be IRC, but you can, optionally, add it:
-# type = irc
+# IRC SERVER: hackint IRC (Tor, IP)
+###############################################################################
+[MESSAGING:hackint]
 channel = joinmarket-pit
-port = 6697
-usessl = true
-
 # For traditional IP:
-#host = irc.darkscience.net
-#socks5 = false
-
-# For Tor (recommended as clearnet alternative):
-host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
-socks5 = true
-socks5_host = localhost
-socks5_port = 9050
-
-## IRC SERVER 2: ILITA IRC (optional IRC alternate, Tor only)
-################################################################################
-[MESSAGING:server2]
-channel = joinmarket-pit
+# host = irc.hackint.org
+# port = 6697
+# usessl = true
+# socks5 = false
+# For Tor (default):
+host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
 port = 6667
 usessl = false
 socks5 = true
 socks5_host = localhost
-
-host = ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
 socks5_port = 9050
-
-## IRC SERVER 3: (backup) hackint IRC (Tor, IP)
-################################################################################
-#[MESSAGING:server3]
-# channel = joinmarket-pit
-# For traditional IP:
-## host = irc.hackint.org
-## port = 6697
-## usessl = true
-## socks5 = false
-# For Tor (default):
-#host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
-#port = 6667
-#usessl = false
-#socks5 = true
-#socks5_host = localhost
-#socks5_port = 9050
 
 [LOGGING]
 # Set the log level for the output to the terminal/console
@@ -173,6 +140,11 @@ merge_algorithm = default
 # for address searching during wallet sync. Command line
 # scripts can use the command line flag `-g` instead.
 gaplimit = 6
+
+# Disable the caching of addresses and scripts when
+# syncing the wallet. You DO NOT need to set this to 'true',
+# unless there is an issue of file corruption or a code bug.
+wallet_caching_disabled = false
 
 # The fee estimate is based on a projection of how many sats/kilo-vbyte
 # are needed to get in one of the next N blocks. N is set here as

--- a/standalone/default.cfg
+++ b/standalone/default.cfg
@@ -80,7 +80,7 @@ hidden_service_dir =
 # Each item has format host:port ; both are required, though port will
 # be 5222 if created in this code.
 # for MAINNET:
-directory_nodes = g3hv4uynnmynqqq2mchf3fcm3yd46kfzmcdogejuckgwknwyq5ya6iad.onion:5222,3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222,odpwaf67rs5226uabcamvypg3y4bngzmfk7255flcdodesqhsvkptaid.onion:5222
+directory_nodes = 3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222,ylegp63psfqh3zk2huckf2xth6dxvh2z364ykjfmvsoze6tkfjceq7qd.onion:5222,odpwaf67rs5226uabcamvypg3y4bngzmfk7255flcdodesqhsvkptaid.onion:5222
 # for SIGNET (testing network):
 # directory_nodes = rr6f6qtleiiwic45bby4zwmiwjrj3jsbmcvutwpqxjziaydjydkk5iad.onion:5222,k74oyetjqgcamsyhlym2vgbjtvhcrbxr4iowd4nv4zk5sehw4v665jad.onion:5222,y2ruswmdbsfl4hhwwiqz4m3sx6si5fr6l3pf62d4pms2b53wmagq3eqd.onion:5222
 


### PR DESCRIPTION
Recreate default config from [current tip of `master` branch](https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/0e45c6991e678525085cf13a029f984ff04ae664).
Most importantly,  darkscience irc server is removed.

Also adapting directory nodes according to [list of directory nodes #1445](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1445).
Most importantly, the default node `g3hv4uyn…` is removed and `ylegp63p…` added.