### PR TITLE
feat: support rpc_cookie_file

### DIFF
--- a/.github/workflows/check-and-update-dependencies.yml
+++ b/.github/workflows/check-and-update-dependencies.yml
@@ -1,8 +1,6 @@
-name: Check and update versions of dependencies
+name: 'dispatch: check and update dependencies'
 
 on:
-  schedule:
-    - cron: '51 6 * * *' # every day at 06:51 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/create-and-publish-docker-dev-manually.yml
+++ b/.github/workflows/create-and-publish-docker-dev-manually.yml
@@ -1,4 +1,4 @@
-name: Manually create and publish Docker image
+name: 'dispatch: build & publish dev docker images'
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       ui_repo_ref:
-        description: 'ui version/branch (e.g. v0.0.10, master, etc.)'
+        description: 'ui version/branch (e.g. v0.4.1, master, etc.)'
         required: true
         default: 'master'
         type: string

--- a/.github/workflows/create-and-publish-docker-on-release.yml
+++ b/.github/workflows/create-and-publish-docker-on-release.yml
@@ -1,4 +1,4 @@
-name: Create and publish Docker image (on release)
+name: 'release: build & publish Docker images'
 
 on:
   release:

--- a/.github/workflows/create-and-publish-docker.yml
+++ b/.github/workflows/create-and-publish-docker.yml
@@ -1,4 +1,4 @@
-name: Create and publish Docker image
+name: 'call: create-and-publish-docker'
 
 on:
   workflow_call:

--- a/.github/workflows/docker-contrib-dinit.yml
+++ b/.github/workflows/docker-contrib-dinit.yml
@@ -1,4 +1,4 @@
-name: Docker jam-contrib-dinit
+name: 'dispatch: build & publish jam-contrib-dinit'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-dependency-version.yml
+++ b/.github/workflows/update-dependency-version.yml
@@ -1,4 +1,4 @@
-name: Check and update version of single dependency
+name: 'call: update-dependency-version'
 
 on:
   workflow_call:

--- a/readme.md
+++ b/readme.md
@@ -98,11 +98,28 @@ The following environment variables control the configuration:
 Variables starting with prefix `JM_` will be applied to `joinmarket.cfg` e.g.:
 - `--env JM_GAPLIMIT=200` will set the `gaplimit` config value to `200`
 
+### RPC authentication
+
+The container supports two methods for Bitcoin RPC authentication:
+
+#### Method 1: user/password
+```sh
+--env JM_RPC_USER="bitcoin" \
+--env JM_RPC_PASSWORD="password"
+```
+
+#### Method 2: cookie authentication
+```sh
+--env JM_RPC_COOKIE_FILE="/path/to/.cookie"
+```
+
+**Note**: If `JM_RPC_COOKIE_FILE` is set, cookie authentication will be used. Otherwise, user/password authentication is used. The cookie file path should be accessible from within the container.
+
 ### Building Notes
 Building a specific release:
 ```sh
 docker build --label "local" \
-        --build-arg JAM_REPO_REF=v0.3.0 \
+        --build-arg JAM_REPO_REF=v0.4.1 \
         --build-arg JM_SERVER_REPO_REF=v0.9.11 \
         --tag "joinmarket-webui/jam-standalone" ./standalone
 ```
@@ -129,6 +146,8 @@ docker run --rm --entrypoint="/bin/bash" -it joinmarket-webui/jam-standalone
 ```
 
 ### Run
+
+#### Using user/password authentication
 ```sh
 docker run --rm -it \
         --add-host host.docker.internal:host-gateway \
@@ -144,6 +163,26 @@ docker run --rm -it \
         --env RESTORE_DEFAULT_CONFIG="true" \
         --env WAIT_FOR_BITCOIND="true" \
         --volume jmdatadir:/root/.joinmarket \
+        --publish "8080:80" \
+        joinmarket-webui/jam-standalone
+```
+
+#### Using cookie authentication
+```sh
+docker run --rm -it \
+        --add-host host.docker.internal:host-gateway \
+        --env JM_RPC_HOST="host.docker.internal" \
+        --env JM_RPC_PORT="18443" \
+        --env JM_RPC_COOKIE_FILE="/bitcoin/.cookie" \
+        --env JM_NETWORK="regtest" \
+        --env APP_USER="joinmarket" \
+        --env APP_PASSWORD="joinmarket" \
+        --env ENSURE_WALLET="true" \
+        --env REMOVE_LOCK_FILES="true" \
+        --env RESTORE_DEFAULT_CONFIG="true" \
+        --env WAIT_FOR_BITCOIND="true" \
+        --volume jmdatadir:/root/.joinmarket \
+        --volume /path/to/bitcoin/data:/bitcoin \
         --publish "8080:80" \
         joinmarket-webui/jam-standalone
 ```


### PR DESCRIPTION
Resolves #167.

Adds support for `rpc_cookie_file` param.

If env var `JM_RPC_COOKIE_FILE` is set, cookie authentication will be used. Otherwise, user/password authentication is used. The cookie file path should be accessible from within the container.

