### PR TITLE
fix: workaround for libsodium v1.0.18 install

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -126,6 +126,13 @@ ENV PATH=/src/scripts:$PATH
 
 WORKDIR /src
 
+# workaround: adjust libsodium download URL in install.sh for legacy 1.0.18 releases
+# TODO: remove this once v0.9.11 is no longer supported and new releases are available
+RUN set -eux \
+    && if grep --quiet "sodium_version='libsodium-1.0.18'" install.sh; then \
+         sed --in-place "s#sodium_url='https://download.libsodium.org/libsodium/releases'#sodium_url='https://download.libsodium.org/libsodium/releases/old'#g" install.sh; \
+       fi
+
 # compile and install JoinMarket
 RUN pip3 config set global.break-system-packages true \
     && ./install.sh --docker-install --without-qt \


### PR DESCRIPTION
It's not great, but the simplest solution to the libsodium install is adjusting the url before installing.
Tried back and forth with locally building it from source, but results in much more overhead than this simple one-liner.
Changing the install.sh manually is not something we'd want, but given there is a new release soon (TM), this can hopefully be removed later again (in a few months?).