### PR TITLE
Add backend info endpoint

### DIFF
--- a/standalone-ng/Dockerfile
+++ b/standalone-ng/Dockerfile
@@ -222,6 +222,9 @@ RUN chmod +x \
 # Copy nginx configuration
 COPY nginx/snippets/proxy-params.conf /etc/nginx/snippets/proxy-params.conf
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+RUN backend_version="$(/opt/venv/bin/python -c 'from importlib.metadata import version; print(version("jmcore"))')" \
+    && sed --in-place "s|__BACKEND_VERSION__|${backend_version}|g" /etc/nginx/conf.d/default.conf
+
 # Remove the default nginx site that conflicts with our config
 RUN rm --force /etc/nginx/sites-enabled/default
 

--- a/standalone-ng/Dockerfile
+++ b/standalone-ng/Dockerfile
@@ -222,8 +222,7 @@ RUN chmod +x \
 # Copy nginx configuration
 COPY nginx/snippets/proxy-params.conf /etc/nginx/snippets/proxy-params.conf
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
-RUN backend_version="$(/opt/venv/bin/python -c 'from importlib.metadata import version; print(version("jmcore"))')" \
-    && sed --in-place "s|__BACKEND_VERSION__|${backend_version}|g" /etc/nginx/conf.d/default.conf
+RUN sed --in-place "s|__BACKEND_VERSION__|${JM_NG_REPO_REF}|g" /etc/nginx/conf.d/default.conf
 
 # Remove the default nginx site that conflicts with our config
 RUN rm --force /etc/nginx/sites-enabled/default

--- a/standalone-ng/nginx/default.conf
+++ b/standalone-ng/nginx/default.conf
@@ -134,7 +134,14 @@ server {
         auth_request /jam/internal/auth;
 
         default_type application/json;
-        return 200 '{"features":{"logs":true},"backend":"ng"}';
+        return 200 '{"features":{"logs":true},"backend":"joinmarket-ng"}';
+    }
+
+    location = /jam/api/v0/info {
+        auth_request /jam/internal/auth;
+
+        default_type application/json;
+        return 200 '{"backend":"joinmarket-ng","version":"__BACKEND_VERSION__"}';
     }
 
     location = /jam/api/v0/log/jmwalletd_stdout.log {

--- a/standalone-ng/nginx/default.conf
+++ b/standalone-ng/nginx/default.conf
@@ -141,7 +141,7 @@ server {
         auth_request /jam/internal/auth;
 
         default_type application/json;
-        return 200 '{"backend":"joinmarket-ng","version":"__BACKEND_VERSION__"}';
+        return 200 '{"backend":{"name":"joinmarket-ng","version":"__BACKEND_VERSION__"}}';
     }
 
     location = /jam/api/v0/log/jmwalletd_stdout.log {

--- a/standalone-ng/nginx/default.conf
+++ b/standalone-ng/nginx/default.conf
@@ -134,7 +134,7 @@ server {
         auth_request /jam/internal/auth;
 
         default_type application/json;
-        return 200 '{"features":{"logs":true},"backend":"joinmarket-ng"}';
+        return 200 '{ "features": { "logs": true } }';
     }
 
     location = /jam/api/v0/info {

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -153,6 +153,7 @@ COPY --chown=tor:tor torrc /etc/tor/torrc
 
 COPY nginx/snippets/proxy-params.conf /etc/nginx/snippets/proxy-params.conf
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+RUN sed --in-place "s|__BACKEND_VERSION__|${JM_SERVER_REPO_REF}|g" /etc/nginx/conf.d/default.conf
 
 COPY --chmod=0755 jam-entrypoint.sh /
 

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -143,7 +143,7 @@ server {
         auth_request /jam/internal/auth;
 
         default_type application/json;
-        return 200 '{"backend":"joinmarket-clientserver","version":"__BACKEND_VERSION__"}';
+        return 200 '{"backend":{"name":"joinmarket-clientserver","version":"__BACKEND_VERSION__"}}';
     }
 
     location /jam/api/v0/log/ {

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -139,6 +139,13 @@ server {
         return 200 '{ "features": { "logs": true } }';
     }
 
+    location = /jam/api/v0/info {
+        auth_request /jam/internal/auth;
+
+        default_type application/json;
+        return 200 '{"backend":"joinmarket-clientserver","version":"__BACKEND_VERSION__"}';
+    }
+
     location /jam/api/v0/log/ {
         auth_request /jam/internal/auth;
 


### PR DESCRIPTION
This pr adds `/jam/api/v0/info` endpoint to both `joinmarket-clientserver` and `joinmarket-ng` standalone images with information about which backend it uses and its version.