### PR TITLE
chore(nginx): disable proxy buffering and increase read timeout

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ docker-build-ui-master *args='':
 [group("docker")]
 docker-build-standalone-ng jam_repo_ref=env('JAM_REPO_REF') jm_ng_repo_ref=env('JM_NG_REPO_REF') *args='':
     @echo "Creating 'standalone-ng' docker image ..."
-    @docker buildx build {{args}} \
+    @docker buildx build --load {{args}} \
         --label "local" \
         --build-arg JAM_REPO_REF={{jam_repo_ref}} \
         --build-arg JM_NG_REPO_REF={{jm_ng_repo_ref}} \
@@ -73,7 +73,7 @@ docker-lint-standalone-ng:
 [group("docker")]
 docker-build-contrib-dinit *args='':
     @echo "Creating 'dinit' docker image ..."
-    @docker buildx build {{args}} \
+    @docker buildx build --load {{args}} \
         --label "local" \
         --tag "joinmarket-webui/jam-contrib-dinit" ./contrib/dinit
 

--- a/standalone-ng/nginx/default.conf
+++ b/standalone-ng/nginx/default.conf
@@ -22,9 +22,9 @@ map $http_x_jm_authorization $jm_auth_present {
 }
 
 map $uri $cache_control {
-    default                                                                  "public, max-age=86400";
-    ~*\.(html|htm)$                                                          "no-cache, no-store, must-revalidate";
-    ~*\.(css|js|json|jpg|jpeg|png|gif|ico|svg|woff|woff2|ttf|otf|eot)$     "public, max-age=31536000, immutable";
+    default                         "public, max-age=86400";  # 1 day for most files
+    ~*\.(html|htm)$                 "no-cache, no-store, must-revalidate";
+    ~*\.(css|js|json|jpg|jpeg|png|gif|ico|svg|woff|woff2|ttf|otf|eot)$  "public, max-age=31536000, immutable";
 }
 
 map $uri $expires_value {
@@ -71,12 +71,13 @@ server {
         proxy_set_header x-jm-authorization "";
 
         # some api requests can take over a minute. play it safe
-        # and allow 5 min (default is 60 sec). increase on demand.
-        proxy_read_timeout 300s;
+        # and allow 21 days (default is 60 sec). change on demand.
+        proxy_read_timeout 21d;
         # allow 5 min to connect (default is 60 sec)
         proxy_connect_timeout 300s;
 
         proxy_pass https://jmwalletd_api_backend;
+        proxy_buffering off;
     }
 
     location = /jmws {
@@ -92,6 +93,7 @@ server {
         proxy_send_timeout 600s;
 
         proxy_pass https://jmwalletd_ws_backend;
+        proxy_buffering off;
     }
 
     location /obwatch/ {
@@ -100,12 +102,13 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
 
-        # allow 5 min (default is 60 sec). increase on demand.
+        # allow 5 min (default is 60 sec). change on demand.
         proxy_read_timeout 300s;
         # allow 5 min to connect (default is 60 sec)
         proxy_connect_timeout 300s;
 
         proxy_pass http://obwatch_backend/;
+        proxy_buffering off;
     }
 
     location = /jam/internal/auth {
@@ -128,6 +131,7 @@ server {
 
         # pass to `/session` which will validate the header
         proxy_pass http://$server_addr:$server_port/api/v1/session;
+        proxy_buffering off;
     }
 
     location = /jam/api/v0/features {

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -68,12 +68,13 @@ server {
         proxy_set_header x-jm-authorization "";
 
         # some api requests can take over a minute. play it safe
-        # and allow 5 min (default is 60 sec). increase on demand.
-        proxy_read_timeout 300s;
+        # and allow 21 days (default is 60 sec). change on demand.
+        proxy_read_timeout 21d;
         # allow 5 min to connect (default is 60 sec)
         proxy_connect_timeout 300s;
 
         proxy_pass https://jmwalletd_api_backend;
+        proxy_buffering off;
     }
 
     location = /jmws {
@@ -90,6 +91,7 @@ server {
         proxy_send_timeout 600s;
 
         proxy_pass https://jmwalletd_ws_backend${JAM_JMWALLETD_WEBSOCKET_PATH};
+        proxy_buffering off;
     }
 
     location /obwatch/ {
@@ -98,13 +100,14 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
 
-        # allow 5 min (default is 60 sec). increase on demand.
+        # allow 5 min (default is 60 sec). change on demand.
         proxy_read_timeout 300s;
         # allow 5 min to connect (default is 60 sec)
         proxy_connect_timeout 300s;
 
         # must proxy via "http" as ob-watcher does not make use of self-signed cert yet
         proxy_pass http://obwatch_backend/;
+        proxy_buffering off;
     }
 
     location = /jam/internal/auth {
@@ -127,6 +130,7 @@ server {
 
         # pass to `/session` which will validate the header
         proxy_pass http://${server_addr}:${server_port}/api/v1/session;
+        proxy_buffering off;
     }
 
     location = /jam/api/v0/features {


### PR DESCRIPTION
Dont buffer or handle timeouts for all requests proxied to joinmarket-ng services.
Adds the following configs:
```
proxy_read_timeout 21d;
proxy_buffering off;
```

e.g. in joinmarket-ng v0.33.0, a `/api/{walletname}/unlock` request returns after rescan is finished. While this is quick on regtest, it might take minutes, even hours on mainnet.
