### PR TITLE
chore: add security headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,12 @@ services:
       NETWORK_CONFIG__NETWORK: testnet
       NETWORK_CONFIG__BITCOIN_NETWORK: regtest
       NETWORK_CONFIG__DIRECTORY_SERVERS: node3.onion:5222, node4.onion:5222
+      WALLET__MIXDEPTH_COUNT: 5 # default: 5
+      WALLET__GAP_LIMIT: 6 # default: 20
+      WALLET__SCAN_RANGE: 1000 # default: 1000
+      WALLET__SMART_SCAN: true # default: true  # Enable smart scan for fast startup
+      WALLET__BACKGROUND_FULL_SCAN: true # default: true # Run full rescan in background after smart scan
+      WALLET__SCAN_LOOKBACK_BLOCKS: 100 # default: 52560 # Blocks to look back during initial smart scan
       MAKER__MIN_SIZE: 30000 # default: 100000
       MAKER__MIN_CONFIRMATIONS: 1 # default: 0
       MAKER__MERGE_ALGORITHM: 'greedy' # default: 'default'

--- a/standalone-ng/Dockerfile
+++ b/standalone-ng/Dockerfile
@@ -229,6 +229,7 @@ RUN chmod +x \
 
 # Copy nginx configuration
 COPY nginx/snippets/proxy-params.conf /etc/nginx/snippets/proxy-params.conf
+COPY nginx/snippets/security-headers.conf /etc/nginx/snippets/security-headers.conf
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 RUN sed --in-place "s|__BACKEND_VERSION__|${JM_NG_REPO_REF}|g" /etc/nginx/conf.d/default.conf
 

--- a/standalone-ng/nginx/default.conf
+++ b/standalone-ng/nginx/default.conf
@@ -44,6 +44,15 @@ server {
     auth_basic off;
     auth_basic_user_file /etc/nginx/.htpasswd;
 
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    
     gzip on;
     gzip_types application/javascript application/json text/css text/plain image/svg+xml;
 

--- a/standalone-ng/nginx/default.conf
+++ b/standalone-ng/nginx/default.conf
@@ -44,14 +44,8 @@ server {
     auth_basic off;
     auth_basic_user_file /etc/nginx/.htpasswd;
 
-    # Security headers
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "no-referrer" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    # add_header_inherit merge; <-- TODO: enable once updated to nginx >=1.29.3.
+    include /etc/nginx/snippets/security-headers.conf;
     
     gzip on;
     gzip_types application/javascript application/json text/css text/plain image/svg+xml;
@@ -61,6 +55,7 @@ server {
 
     location / {
         include /etc/nginx/snippets/proxy-params.conf;
+        include /etc/nginx/snippets/security-headers.conf;
 
         try_files $uri $uri/ /index.html;
 
@@ -70,6 +65,7 @@ server {
 
     location /api/ {
         include /etc/nginx/snippets/proxy-params.conf;
+        include /etc/nginx/snippets/security-headers.conf;
 
         proxy_http_version 1.1;
         proxy_set_header Connection "";
@@ -91,6 +87,7 @@ server {
 
     location = /jmws {
         include /etc/nginx/snippets/proxy-params.conf;
+        include /etc/nginx/snippets/security-headers.conf;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -107,6 +104,7 @@ server {
 
     location /obwatch/ {
         include /etc/nginx/snippets/proxy-params.conf;
+        include /etc/nginx/snippets/security-headers.conf;
 
         proxy_http_version 1.1;
         proxy_set_header Connection "";
@@ -146,6 +144,8 @@ server {
     location = /jam/api/v0/features {
         auth_request /jam/internal/auth;
 
+        include /etc/nginx/snippets/security-headers.conf;
+
         default_type application/json;
         return 200 '{ "features": { "logs": true } }';
     }
@@ -153,12 +153,16 @@ server {
     location = /jam/api/v0/info {
         auth_request /jam/internal/auth;
 
+        include /etc/nginx/snippets/security-headers.conf;
+
         default_type application/json;
         return 200 '{"backend":{"name":"joinmarket-ng","version":"__BACKEND_VERSION__"}}';
     }
 
     location = /jam/api/v0/log/jmwalletd_stdout.log {
         auth_request /jam/internal/auth;
+
+        include /etc/nginx/snippets/security-headers.conf;
 
         alias /var/log/jam-ng/jmwalletd/current;
 
@@ -169,6 +173,8 @@ server {
 
     location /jam/api/v0/log/ {
         auth_request /jam/internal/auth;
+
+        include /etc/nginx/snippets/security-headers.conf;
 
         alias /var/log/jam-ng/;
 

--- a/standalone-ng/nginx/snippets/security-headers.conf
+++ b/standalone-ng/nginx/snippets/security-headers.conf
@@ -1,0 +1,8 @@
+add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'none'; object-src 'none'; frame-ancestors 'none';" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "no-referrer" always;
+add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), fullscreen=(), payment=(), usb=()" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;

--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -80,6 +80,7 @@ RUN --mount=type=bind,from=ui-builder,source=/usr/src/jam,target=/tmp/jam \
     fi
 
 COPY nginx/snippets/proxy-params.conf /etc/nginx/snippets/proxy-params.conf
+COPY nginx/snippets/security-headers.conf /etc/nginx/snippets/security-headers.conf
 # each time nginx is started it will perform variable substition in all template
 # files found in `/etc/nginx/templates/*.template`, and copy the results (without
 # the `.template` suffix) into `/etc/nginx/conf.d/`.

--- a/ui-only/nginx/snippets/security-headers.conf
+++ b/ui-only/nginx/snippets/security-headers.conf
@@ -1,0 +1,8 @@
+add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'none'; object-src 'none'; frame-ancestors 'none';" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "no-referrer" always;
+add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), fullscreen=(), payment=(), usb=()" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -41,6 +41,15 @@ server {
     access_log /var/log/nginx/access_jam.log;
     error_log /var/log/nginx/error_jam.log;
 
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+
     gzip on;
     gzip_types application/javascript application/json text/css image/svg+xml;
 

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -41,14 +41,8 @@ server {
     access_log /var/log/nginx/access_jam.log;
     error_log /var/log/nginx/error_jam.log;
 
-    # Security headers
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "no-referrer" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header_inherit merge;
+    include /etc/nginx/snippets/security-headers.conf;
 
     gzip on;
     gzip_types application/javascript application/json text/css image/svg+xml;


### PR DESCRIPTION
Supersedes #13 

Adds the following headers:
```
add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';";
add_header X-Frame-Options "DENY" always;
add_header X-Content-Type-Options "nosniff" always;
add_header X-XSS-Protection "1; mode=block" always;
add_header Referrer-Policy "no-referrer" always;
add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), fullscreen=(), payment=(), usb=()" always;
add_header Cross-Origin-Resource-Policy "same-origin" always;
add_header Cross-Origin-Opener-Policy "same-origin" always;
```

## How to test
```
just docker-build-standalone-ng-main
just docker-build-ui-master
just regtest-build --no-cache
just regtest-up
```
Then visit: http://localhost:42081 and check that everything is working as expected.