### PR TITLE
chore(nginx): add base-uri and form-action to csp header

### DIFF
--- a/standalone-ng/nginx/default.conf
+++ b/standalone-ng/nginx/default.conf
@@ -43,15 +43,16 @@ server {
 
     auth_basic off;
     auth_basic_user_file /etc/nginx/.htpasswd;
-
-    # add_header_inherit merge; <-- TODO: enable once updated to nginx >=1.29.3.
-    include /etc/nginx/snippets/security-headers.conf;
     
     gzip on;
     gzip_types application/javascript application/json text/css text/plain image/svg+xml;
 
     root /app;
     index index.html;
+
+    server_tokens off;
+    # add_header_inherit merge; <-- TODO: enable once updated to nginx >=1.29.3 (see ui-only image)
+    include /etc/nginx/snippets/security-headers.conf;
 
     location / {
         include /etc/nginx/snippets/proxy-params.conf;

--- a/standalone-ng/nginx/snippets/security-headers.conf
+++ b/standalone-ng/nginx/snippets/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'none'; object-src 'none'; frame-ancestors 'none';" always;
+add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 add_header X-Frame-Options "DENY" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "1; mode=block" always;

--- a/ui-only/nginx/snippets/security-headers.conf
+++ b/ui-only/nginx/snippets/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'none'; object-src 'none'; frame-ancestors 'none';" always;
+add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 add_header X-Frame-Options "DENY" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "1; mode=block" always;

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -41,14 +41,15 @@ server {
     access_log /var/log/nginx/access_jam.log;
     error_log /var/log/nginx/error_jam.log;
 
-    add_header_inherit merge;
-    include /etc/nginx/snippets/security-headers.conf;
-
     gzip on;
     gzip_types application/javascript application/json text/css image/svg+xml;
 
     root /app;
     index index.html;
+
+    server_tokens off;
+    add_header_inherit merge;
+    include /etc/nginx/snippets/security-headers.conf;
 
     location / {
         include /etc/nginx/snippets/proxy-params.conf;


### PR DESCRIPTION
Addendum to #13 after comment by @kishore08-07 https://github.com/joinmarket-webui/jam/pull/1325#discussion_r3548620792

Adds `base-uri 'self'; form-action 'self'` to the csp header and disables sending the nginx verison (`server_tokens off;`).