### PR TITLE
fix: redirect jmwalletd stderr to stdout to capture operational logs

### DIFF
--- a/standalone-ng/s6-overlay/s6-rc.d/jmwalletd-svc/run
+++ b/standalone-ng/s6-overlay/s6-rc.d/jmwalletd-svc/run
@@ -1,0 +1,2 @@
+#!/command/with-contenv sh
+exec /opt/venv/bin/jmwalletd 2>&1


### PR DESCRIPTION
**Context:**

Currently, the logs page shows http req logs only. The daemon logs (wallet synchronization, descriptor info, errors) are missing in the logfile and its visible only via docker logs on the host.

**Changes:**
- Added a local `run` script override for `jmwalletd-svc` to redirect `stderr to stdout (2>&1)`.
- Now both streams are captured together by the s6 logging daemon, the ui logs page now shows the complete operational logs alongside HTTP statuses.

**Tested & Verified:**
- Verified that `/var/log/jam-ng/jmwalletd/current` inside the container captures both daemon logs and HTTP status messages.
- Confirmed the UI Logs modal displays the combined log stream correctly.
<img width="1333" height="626" alt="Screenshot from 2026-07-10 17-49-22" src="https://github.com/user-attachments/assets/761db3f5-dd0f-4216-8779-5deffe5dad15" />

Closes #200 